### PR TITLE
fix: Use env variable name in calendar invite

### DIFF
--- a/pages/api/confirm.ts
+++ b/pages/api/confirm.ts
@@ -66,7 +66,7 @@ export default async function handler(
   const response = await createCalendarAppointment({
     ...validObject,
     requestId: hash,
-    summary: `${validObject.duration} minute meeting with Tim`,
+    summary: `${validObject.duration} minute meeting with ${process.env.NEXT_PUBLIC_OWNER_NAME ?? "me"}`,
   })
 
   const details = await response.json()


### PR DESCRIPTION
Hey Tim, thanks for making this repo!

Found an instance of "Tim" instead of the user's name in the application. This pull request swaps that out for the environment variable instead. Cheers!