### PR TITLE
fix: Resolve timezone bugs

### DIFF
--- a/components/availability/date/Calendar.tsx
+++ b/components/availability/date/Calendar.tsx
@@ -64,6 +64,7 @@ export default function Calendar({
         </div>
       ))}
       {days.map((day) => {
+        const availabilityTest = offers[day.toString()] ?? []
         return (
           <DayButton
             key={day.toString()}
@@ -72,6 +73,7 @@ export default function Calendar({
               openSlots: offers[day.toString()]?.length ?? 0,
               maximumAvailability,
             })}
+            hasAvailability={availabilityTest.length > 0}
           />
         )
       })}

--- a/components/availability/date/DayButton.tsx
+++ b/components/availability/date/DayButton.tsx
@@ -8,6 +8,7 @@ import Day from "@/lib/day"
 type DayProps = {
   date: Day
   availabilityScore: number
+  hasAvailability: boolean
 } & DetailedHTMLProps<
   ButtonHTMLAttributes<HTMLButtonElement>,
   HTMLButtonElement
@@ -16,6 +17,7 @@ type DayProps = {
 export default function DayButton({
   date,
   availabilityScore,
+  hasAvailability,
   ...props
 }: DayProps): JSX.Element {
   const {
@@ -29,13 +31,11 @@ export default function DayButton({
 
   const isToday = date.toString() === now.toString()
 
-  const isOutOfRange = date < now || date > end || date < start
-
   const isSelected = selectedDate
     ? date.toString() === selectedDate.toString()
     : false
 
-  const isDisabled = isOutOfRange || availabilityScore === 0
+  const isDisabled = !hasAvailability
 
   return (
     <button

--- a/lib/availability/getPotentialTimes.ts
+++ b/lib/availability/getPotentialTimes.ts
@@ -23,8 +23,8 @@ export default function getPotentialTimes({
 
   // Sort the slots by start time
   const days = eachDayOfInterval({
-    start: start.toInterval().start,
-    end: end.toInterval().end,
+    start: start.toInterval("Etc/GMT").start,
+    end: end.toInterval("Etc/GMT").end,
   })
   days.forEach((day) => {
     const dayOfWeek = day.getDay()

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns a string representation of the Date object
+ * in 'YYYY-MM-DD' format, respecting the user's timezone.
+ *
+ * @returns {string} The formatted date string.
+ */
+export default function localeDayString(date: Date): string {
+  const dateOptions: Intl.DateTimeFormatOptions = { 
+    year: 'numeric', 
+    month: '2-digit', 
+    day: '2-digit', 
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone 
+  };
+  const dateString: string = date.toLocaleString('en-ca', dateOptions).replace(/\//g, '-');
+  return dateString
+}

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns-tz'
+
 /**
  * Returns a string representation of the Date object
  * in 'YYYY-MM-DD' format, respecting the user's timezone.
@@ -6,11 +8,8 @@
  */
 export default function localeDayString(date: Date): string {
   const dateOptions: Intl.DateTimeFormatOptions = { 
-    year: 'numeric', 
-    month: '2-digit', 
-    day: '2-digit', 
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone 
   };
-  const dateString: string = date.toLocaleString('en-ca', dateOptions).replace(/\//g, '-');
+  const dateString: string = format( date, 'yyyy-MM-dd', { timeZone: dateOptions.timeZone } )
   return dateString
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,6 +22,7 @@ import {
   mapStringsToDates,
 } from "@/lib/availability/helpers"
 import Day from "@/lib/day"
+import localeDayString from "@/lib/locale"
 
 export type PageProps = InferGetServerSidePropsType<typeof getServerSideProps>
 
@@ -61,9 +62,12 @@ function Page({
   // with some availability.
   useEffect(() => {
     if (!selectedDate && slots.length > 0) {
+      const date: Date = slots[0].start;
+      const dateString: string = localeDayString(date)
+
       dispatch({
         type: "SET_SELECTED_DATE",
-        payload: Day.dayFromDate(slots[0].start),
+        payload: Day.dayFromString(dateString), //payload from date respecting timezone
       })
     }
     // Run once, on initial render.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -52,8 +52,8 @@ function Page({
 
   const slots = offers.filter((slot) => {
     return (
-      slot.start >= startDay.toInterval().start &&
-      slot.end <= endDay.toInterval().end
+      slot.start >= startDay.toInterval("Etc/GMT").start &&
+      slot.end <= endDay.toInterval("Etc/GMT").end
     )
   })
 


### PR DESCRIPTION
## Overview

A few tweaks to get the availability and timezones working properly.

* Force interval Date objects to use UTC when generated via `"Etc/GMT"` timezone
* Switch DayButton isDisabled to track if the offers array has available appointemnts
* Create another function to generate a date string from the user's local timezone
  * This resolves issues of appointments being shunted to other dates based on UTC vs User local timezone
  * This might be better placed in helpers.ts. I put this in it's own file in `./lib`

Fixes #16 
Fixes #17