### PR TITLE
fix: Force getDateRangeInterval to use "Etc/GMT"

### DIFF
--- a/components/availability/date/Calendar.tsx
+++ b/components/availability/date/Calendar.tsx
@@ -21,6 +21,7 @@ export default function Calendar({
   const { start: startDate, end: endDate } = getDateRangeInterval({
     start,
     end,
+    timeZone: "Etc/GMT",
   })
 
   // Handles when the date changes due to the selected timezone
@@ -32,7 +33,7 @@ export default function Calendar({
     // an incomplete row.
     end: endOfWeek(addDays(endDate, 2)),
   }).map((day) => Day.dayFromDate(day))
-
+  
   // Remove cases where the first week is empty.
   // (Usually timezone changing related)
   const firstWeek = days.at(6)


### PR DESCRIPTION
Resolves timezone bug with getDateRangeInterval

Resolves #20 